### PR TITLE
Add Vitest setup and CSV parser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.453.0",
@@ -23,6 +24,9 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.5.3",
-    "vite": "^5.4.6"
+    "vite": "^5.4.6",
+    "vitest": "^1.5.3",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.1"
   }
 }

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { CircleCheck, Squircle, Upload } from 'lucide-react';
 import { Question } from '../types/game';
+import { parseCSV } from '../utils/parseCSV';
 
 interface FileUploadProps {
   onQuestionsLoad: (questions: Question[]) => void;
@@ -163,44 +164,6 @@ const FileUpload: React.FC<FileUploadProps> = ({ onQuestionsLoad }) => {
       : null;
   };
 
-  const parseCSV = (text: string): Question[] => {
-    const lines = text.split('\n')
-      .map(line => line.trim())
-      .filter(line => line.length > 0);
-    
-    const categories = lines[0].split(',').map(cat => cat.trim());
-    const questions: Question[] = [];
-    
-    for (let i = 1; i < lines.length; i += 3) {
-      const questionRow = lines[i]?.split(',').map(q => q.trim());
-      const answerRow = lines[i + 1]?.split(',').map(a => a.trim());
-      const imageRow = lines[i + 2]?.split(',').map(img => img.trim());
-      
-      if (!questionRow || !answerRow) break;
-
-      const rowIndex = Math.floor((i - 1) / 3);
-      const pointValue = (rowIndex + 1) * 200;
-
-      categories.forEach((category, index) => {
-        const question = questionRow[index];
-        const answer = answerRow[index];
-        const imageUrl = imageRow?.[index];
-
-        if (question && answer) {
-          questions.push({
-            category,
-            points: pointValue,
-            question,
-            answer,
-            imageUrl: imageUrl && !isNoneValue(imageUrl) ? imageUrl : undefined,
-            isAnswered: false,
-          });
-        }
-      });
-    }
-
-    return questions;
-  };
 
   const processFile = async (file: File) => {
     if (file.type !== 'text/csv' && !file.name.endsWith('.csv')) {

--- a/src/utils/__tests__/parseCSV.test.ts
+++ b/src/utils/__tests__/parseCSV.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { parseCSV } from '../parseCSV';
+
+describe('parseCSV', () => {
+  it('parses a CSV string into questions', () => {
+    const csv = [
+      'Math,Science',
+      'What is 2+2?,What is H2O?',
+      '4,Water',
+      'none,none',
+      'What is 3x3?,What planet is known as the Red Planet?',
+      '9,Mars',
+      'none,none'
+    ].join('\n');
+
+    const questions = parseCSV(csv);
+
+    expect(questions).toHaveLength(4);
+    expect(questions[0]).toEqual({
+      category: 'Math',
+      points: 200,
+      question: 'What is 2+2?',
+      answer: '4',
+      imageUrl: undefined,
+      isAnswered: false,
+    });
+    expect(questions[1].category).toBe('Science');
+    expect(questions[2].points).toBe(400);
+    expect(questions[3].category).toBe('Science');
+  });
+});

--- a/src/utils/parseCSV.ts
+++ b/src/utils/parseCSV.ts
@@ -1,0 +1,43 @@
+import { Question } from '../types/game';
+
+const isNoneValue = (value: string): boolean => value.trim().toLowerCase() === 'none';
+
+export const parseCSV = (text: string): Question[] => {
+  const lines = text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+
+  const categories = lines[0].split(',').map(cat => cat.trim());
+  const questions: Question[] = [];
+
+  for (let i = 1; i < lines.length; i += 3) {
+    const questionRow = lines[i]?.split(',').map(q => q.trim());
+    const answerRow = lines[i + 1]?.split(',').map(a => a.trim());
+    const imageRow = lines[i + 2]?.split(',').map(img => img.trim());
+
+    if (!questionRow || !answerRow) break;
+
+    const rowIndex = Math.floor((i - 1) / 3);
+    const pointValue = (rowIndex + 1) * 200;
+
+    categories.forEach((category, index) => {
+      const question = questionRow[index];
+      const answer = answerRow[index];
+      const imageUrl = imageRow?.[index];
+
+      if (question && answer) {
+        questions.push({
+          category,
+          points: pointValue,
+          question,
+          answer,
+          imageUrl: imageUrl && !isNoneValue(imageUrl) ? imageUrl : undefined,
+          isAnswered: false,
+        });
+      }
+    });
+  }
+
+  return questions;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,10 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
   plugins: [
     react(),
     {


### PR DESCRIPTION
## Summary
- add Vitest and Testing Library dependencies
- hook up Vitest in vite config and npm scripts
- extract CSV parsing logic to `parseCSV` util
- update `FileUpload` to use util
- add unit test for `parseCSV`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb3fed714832f8ad69ae599ea4019