### PR TITLE
Add audio helpers and click sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,15 @@ audio files are located in `public/Sounds`:
 - `zapsplat_multimedia_game_sound_negative_error_fail_plonky_synth_002_81113.mp3`
 - `zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3`
 
-Sound helpers let you play these effects from your components:
+Sound helpers let you trigger effects from your React components:
 
 ```ts
-import { playSound } from './utils/sound';
+import { playCorrect } from './utils/sounds';
 
-playSound('jeopardy-ding-101soundboards.mp3');
+playCorrect();
 ```
+
+Use `setSoundEnabled(false)` to mute all effect playback.
 
 ## Technical Stack
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { setSoundEnabled } from './utils/sounds';
 import './index.css';
 import GameBoard from './components/GameBoard';
 import QuestionModal from './components/QuestionModal';
@@ -47,6 +48,7 @@ function App() {
     }
 
     setIsAudioMuted(!soundEnabled);
+    setSoundEnabled(soundEnabled);
 
     if (audioRef.current) {
       audioRef.current.volume = 0.5;
@@ -89,6 +91,7 @@ function App() {
       ...prev,
       settings: { ...prev.settings, soundEnabled: !newMuted },
     }));
+    setSoundEnabled(!newMuted);
 
     if (audioRef.current) {
       if (newMuted) {
@@ -173,6 +176,7 @@ function App() {
 
       const shouldPlay = DEFAULT_GAME_STATE.settings.soundEnabled;
       setIsAudioMuted(!shouldPlay);
+      setSoundEnabled(shouldPlay);
 
       // Restart the theme song
       if (audioRef.current && shouldPlay) {

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Question } from '../types/game';
+import { playClick } from '../utils/sounds';
 import { Image as ImageIcon } from 'lucide-react';
 
 interface GameBoardProps {
@@ -63,7 +64,12 @@ const GameBoard: React.FC<GameBoardProps> = ({ questions, categories, onQuestion
                 } text-[#EDF2EF] p-4 h-24 flex items-center justify-center text-3xl font-bold rounded-xl shadow-lg transition-all duration-200 border-2 ${
                   question && !question.isAnswered ? 'border-[#FFB411]/30' : 'border-[#1A365D]'
                 }`}
-                onClick={() => question && !question.isAnswered && onQuestionSelect(question)}
+                onClick={() => {
+                  if (question && !question.isAnswered) {
+                    playClick();
+                    onQuestionSelect(question);
+                  }
+                }}
                 disabled={!question || question.isAnswered}
               >
                 <div className="relative z-10 flex flex-col items-center gap-2">

--- a/src/utils/sounds.ts
+++ b/src/utils/sounds.ts
@@ -2,23 +2,46 @@ export const correctSound = new Audio('/Sounds/jeopardy-ding-101soundboards.mp3'
 export const incorrectSound = new Audio('/Sounds/jeopardy-incorrect-101soundboards.mp3');
 export const dailyDoubleSound = new Audio('/Sounds/daily-double-101soundboards.mp3');
 export const thinkMusic = new Audio('/Sounds/jeopardy-think-101soundboards.mp3');
+export const clickSound = new Audio('/Sounds/zapsplat_multimedia_click_button_short_sharp_73510.mp3');
+
+let enabled = true;
+
+export const setSoundEnabled = (value: boolean): void => {
+  enabled = value;
+  if (!enabled) {
+    correctSound.pause();
+    incorrectSound.pause();
+    dailyDoubleSound.pause();
+    thinkMusic.pause();
+    clickSound.pause();
+    correctSound.currentTime = 0;
+    incorrectSound.currentTime = 0;
+    dailyDoubleSound.currentTime = 0;
+    thinkMusic.currentTime = 0;
+    clickSound.currentTime = 0;
+  }
+};
 
 export const playCorrect = (): void => {
+  if (!enabled) return;
   correctSound.currentTime = 0;
   correctSound.play().catch(console.warn);
 };
 
 export const playIncorrect = (): void => {
+  if (!enabled) return;
   incorrectSound.currentTime = 0;
   incorrectSound.play().catch(console.warn);
 };
 
 export const playDailyDouble = (): void => {
+  if (!enabled) return;
   dailyDoubleSound.currentTime = 0;
   dailyDoubleSound.play().catch(console.warn);
 };
 
 export const playThinkMusic = (): void => {
+  if (!enabled) return;
   thinkMusic.currentTime = 0;
   thinkMusic.loop = true;
   thinkMusic.play().catch(console.warn);
@@ -27,5 +50,11 @@ export const playThinkMusic = (): void => {
 export const stopThinkMusic = (): void => {
   thinkMusic.pause();
   thinkMusic.currentTime = 0;
+};
+
+export const playClick = (): void => {
+  if (!enabled) return;
+  clickSound.currentTime = 0;
+  clickSound.play().catch(console.warn);
 };
 


### PR DESCRIPTION
## Summary
- manage sound settings globally
- play click effect when selecting a question
- update README audio docs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_685eb75ef340832f9293b6276b0214c5